### PR TITLE
Fix bug where collection changed while enumerating

### DIFF
--- a/FxSsh/SshServer.cs
+++ b/FxSsh/SshServer.cs
@@ -66,7 +66,7 @@ namespace FxSsh
                 _isDisposed = true;
                 _started = false;
 
-                foreach (var session in _sessions)
+                foreach (var session in _sessions.ToArray())
                 {
                     try
                     {


### PR DESCRIPTION
Calling `SshServer.Stop()` resulted in `InvalidOperationException` "Collection was modified; enumeration operation may not execute", as `Disconnect` mutates the session. Resolved by copying `_sessions` before enumerating.